### PR TITLE
Use Relaxed Geometry for AFLOW

### DIFF
--- a/scripts/data/get_aflow_csv.py
+++ b/scripts/data/get_aflow_csv.py
@@ -12,7 +12,7 @@ MATCHBOOK = (
     'enthalpy_formation_atom(*),Egap(*),Egap_type(*),'
     'dft_type(*),ldau_type(*),species_pp_ZVAL(*),energy_cutoff(*),'
     'energy_atom(*),density(*),'#volume_cell(*),'
-    'geometry_orig,positions_fractional,compound' # geometry parameters needed for unit cell
+    'geometry,positions_fractional,compound' # geometry parameters needed for unit cell
     )
 DIRECTIVES = '$paging(0)'
 summons = MATCHBOOK+","+DIRECTIVES


### PR DESCRIPTION
Use `geometry` instead of `geoemetry_orig` when pulling AFLOW data.

https://aflowlib.duke.edu/AFLOWDATA/ICSD_WEB/TET/O2Ti1_ICSD_31330/?geometry vs https://aflowlib.duke.edu/AFLOWDATA/ICSD_WEB/TET/O2Ti1_ICSD_31330/?geometry_orig